### PR TITLE
Add compilation, test, and benchmark instructions for the non-initiated

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,30 @@ If you want to build the benchmarks, you will also need the following:
 Use the standard approach to building a Meson project: this will build both a
 static and a shared library by default.
 
+### Setup build directory
+
+```bash
+meson build
+```
+
+### Compile project
+
+```bash
+meson compile -C build
+```
+
+### Run tests
+
+```bash
+meson test -C build
+```
+
+### Run benchmarks
+
+```bash
+meson compile -C build count-eq-bench
+```
+
 ## What's your platform support?
 
 Our goal is supporting all of the [Tier 1 platforms for


### PR DESCRIPTION
I have never used `meson` before and having these would have helped me get start more quickly.

This is kind of separate, but sure if one can improve the output of meson when `hypothesis` isn't available?

```
meson build
...
Program python3 (cffi, hypothesis) found: NO modules: cffi
Program python3 (cffi, pytest_benchmark) found: NO modules: cffi
```

The output feels pretty backwards.